### PR TITLE
Use generic get_ip function in oscrecv.py

### DIFF
--- a/oscrecv.py
+++ b/oscrecv.py
@@ -1,16 +1,26 @@
-import lighthouse
+#!/usr/bin/env python
+"""
+oscrecv.py
+
+Run an OSCServer to control the lamp from touchOSC.
+"""
 import types
+
 from OSC import OSCServer
 
+import lighthouse
+import util
 
 recvPort = 7000
 
-
 class ServerLighthouse(object):
 
-    def __init__(self, address='192.168.1.145', recvPort=recvPort):
+    def __init__(self, address=None, recvPort=recvPort):
 
+        if address is None:
+            address = util.get_ip()[0] # Just use first detected address.
         self.address = address
+
         self.recvPort = recvPort
 
         # Setup a reciever for OSC.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyOSC
+netifaces

--- a/util.py
+++ b/util.py
@@ -1,6 +1,8 @@
 from __future__ import division
 import platform
 
+from netifaces import interfaces, ifaddresses, AF_INET
+
 def get_default_port():
     if platform.system() == 'Linux':
         return '/dev/ttyUSB0'
@@ -24,3 +26,23 @@ def tilt_to_dmx(int_tilt):
     past vertical (light can go past 90 deg) is simply 90+
     """
     return int((int_tilt + 30) * (256/240))
+
+def filter_out_ipv6_and_local_addresses(addresses):
+    for x in addresses:
+        if ':' in x:
+            continue
+        if x.startswith('172.'):
+            continue
+        if x.startswith('127.'):
+            continue
+        yield x
+
+def get_ip():
+    d_all_addresses = {}
+    for interface_name in interfaces():
+        addr = ifaddresses(interface_name)
+        for family in addr.itervalues():
+            for address in family:
+                address['addr']
+                d_all_addresses[address['addr']] = 1
+    return list(filter_out_ipv6_and_local_addresses(d_all_addresses.keys()))


### PR DESCRIPTION
Replace the hard coded address in oscrecv.py with the first detected
system address.

Making a pull request of this, as it brings in a dependency and needs testing that I can't do. Get it by updating to this branch, then running:

```
pip install --pre -r requirements.txt
```

(pre is so pip can pull in pyOSC)

Please merge after testing that this branch of oscrecv.py still works on OS X.
